### PR TITLE
basic error handling

### DIFF
--- a/t4_analyzer.lex
+++ b/t4_analyzer.lex
@@ -68,6 +68,7 @@ int line_number = 1;
 
 \n 											{
 													debug("(l.%d) Newline detected\n", line_number);
+													setCurrentLine(line_number);
 													line_number++;
 													return '\n';
 												}

--- a/t4_header.h
+++ b/t4_header.h
@@ -21,6 +21,9 @@ Dict* dict_keyExists(const char* restricted);
 extern int DEBUG;
 int debug(const char*, ...);
 
+/* E R R O R  H A N D L I N G */
+void setCurrentLine(int);
+
 /* E R R O R  C O L O R */
 void colorize_err_out();
 void reset_err_color();

--- a/t4_parser_gen.y
+++ b/t4_parser_gen.y
@@ -15,6 +15,7 @@ int yylex(void);
 Dict* head = NULL;
 Dict* tail = NULL;
 int DEBUG = 0;
+int current_line = 1;
 %}
 
 //%define parse.error verbose
@@ -66,6 +67,8 @@ statement:
 		| WHILE '(' condition ')' ':' '\n' stmt_list									{ $$ = opr(WHILE, 2, $3, $7); }
 		| IF '(' condition ')' ':' '\n' stmt_list %prec IFX						{ $$ = opr(IF, 2, $3, $7); }
 		| IF '(' condition ')' ':' '\n' stmt_list ELSE ':' '\n' stmt_list		{ $$ = opr(IF, 3, $3, $7, $11); }
+		| error '\n'									{ yyclearin; }
+		| '\t' error									{ yyclearin; }
 		;
 
 stmt_list:
@@ -212,9 +215,14 @@ void freeNode(NodeType *p) {
    free (p);
 }
 
+void setCurrentLine(int line){
+	current_line = line;
+}
+
+
 void yyerror(char *s){
 	colorize_err_out();
-   fprintf(stderr, "%s\n", s);
+	fprintf(stderr, "%d: %s\n", current_line, s);
 	reset_err_color();
 }
 


### PR DESCRIPTION
Simple Error handling functional. 
Line of error will be printed with the corresponding error message.

Problem:
When working with an umlaut (or special characters) like ä,ö,ü the error message will be printed twice.  